### PR TITLE
Close #38 - Add Syntax with === and !==

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Deps {
-  val hedgehogVersion = "7ab9f74d7ca93864170cda181f4b4909156c7413"
+  val hedgehogVersion = "ffeaf3365a021a918df9482cf82971c3bbadb0d6"
   val hedgehogRepo =
     Resolver.url(
       "bintray-scala-hedgehog",

--- a/src/main/scala/kevinlee/fp/Equal.scala
+++ b/src/main/scala/kevinlee/fp/Equal.scala
@@ -1,5 +1,7 @@
 package kevinlee.fp
 
+import kevinlee.fp.instances._
+
 /**
   * @author Kevin Lee
   * @since 2019-04-22
@@ -44,7 +46,22 @@ trait Equal[F] {
   }
 }
 
-object Equal extends ListEqualInstance with VectorEqualInstance {
+object Equal
+  extends NatualEqual
+    with BooleanEqualInstance
+    with IntEqualInstance
+    with ShortEqualInstance
+    with LongEqualInstance
+    with CharEqualInstance
+    with FloatEqualInstance
+    with DoubleEqualInstance
+    with StringEqualInstance
+    with BigIntEqualInstance
+    with BigDecimalEqualInstance
+    with ListEqualInstance
+    with VectorEqualInstance
+
+trait NatualEqual {
   def equalA[A]: Equal[A] = new Equal[A] {
     @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     def equal(x: A, y: A): Boolean = x == y

--- a/src/main/scala/kevinlee/fp/JustSyntax.scala
+++ b/src/main/scala/kevinlee/fp/JustSyntax.scala
@@ -1,9 +1,9 @@
 package kevinlee.fp
 
-import kevinlee.fp.syntax.EitherSyntax
+import kevinlee.fp.syntax.{EitherSyntax, EqualSyntax}
 
 /**
   * @author Kevin Lee
   * @since 2019-05-26
   */
-object JustSyntax extends EitherSyntax
+object JustSyntax extends EqualSyntax with EitherSyntax

--- a/src/main/scala/kevinlee/fp/instances/BigDecimalInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/BigDecimalInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait BigDecimalEqualInstance {
+  implicit val bigDecimalEqual: Equal[BigDecimal] = new Equal[BigDecimal] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: BigDecimal, y: BigDecimal): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/instances/BigIntInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/BigIntInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait BigIntEqualInstance {
+  implicit val bigIntEqual: Equal[BigInt] = new Equal[BigInt] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: BigInt, y: BigInt): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/instances/BooleanInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/BooleanInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait BooleanEqualInstance {
+  implicit val booleanEqual: Equal[Boolean] = new Equal[Boolean] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: Boolean, y: Boolean): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/instances/CharInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/CharInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait CharEqualInstance {
+  implicit val charEqual: Equal[Char] = new Equal[Char] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: Char, y: Char): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/instances/DoubleInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/DoubleInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait DoubleEqualInstance {
+  implicit val doubleEqual: Equal[Double] = new Equal[Double] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: Double, y: Double): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/instances/FloatInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/FloatInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait FloatEqualInstance {
+  implicit val floatEqual: Equal[Float] = new Equal[Float] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: Float, y: Float): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/instances/IntInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/IntInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait IntEqualInstance {
+  implicit val intEqual: Equal[Int] = new Equal[Int] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: Int, y: Int): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/instances/LongInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/LongInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait LongEqualInstance {
+  implicit val longEqual: Equal[Long] = new Equal[Long] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: Long, y: Long): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/instances/ShortInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/ShortInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait ShortEqualInstance {
+  implicit val shortEqual: Equal[Short] = new Equal[Short] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: Short, y: Short): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/instances/StringInstances.scala
+++ b/src/main/scala/kevinlee/fp/instances/StringInstances.scala
@@ -1,0 +1,14 @@
+package kevinlee.fp.instances
+
+import kevinlee.fp.Equal
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+trait StringEqualInstance {
+  implicit val stringEqual: Equal[String] = new Equal[String] {
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+    override def equal(x: String, y: String): Boolean = x == y
+  }
+}

--- a/src/main/scala/kevinlee/fp/syntax/EitherSyntax.scala
+++ b/src/main/scala/kevinlee/fp/syntax/EitherSyntax.scala
@@ -22,7 +22,7 @@ object EitherOps extends EitherFunctions {
     def castL[C]: Either[C, B] = EitherOps.castL(r)
   }
 
-  final class RightBiasedEither[A, B](val e: Either[A, B]) extends AnyVal {
+  final class RightBiasedEither[A, B] private[fp] (val e: Either[A, B]) extends AnyVal {
     /** Executes the given side-effecting function if this is a `Right`.
       *
       *  {{{

--- a/src/main/scala/kevinlee/fp/syntax/EqualSyntax.scala
+++ b/src/main/scala/kevinlee/fp/syntax/EqualSyntax.scala
@@ -1,0 +1,26 @@
+package kevinlee.fp.syntax
+
+import kevinlee.fp.Equal
+
+import scala.language.implicitConversions
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+object EqualSyntax {
+  final class EqualOps[A] private[syntax] (val value: A) extends AnyVal {
+    def ===(other: A)(implicit E: Equal[A]): Boolean =
+      E.equal(value, other)
+    def !==(other: A)(implicit E: Equal[A]): Boolean =
+      !E.equal(value, other)
+  }
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.ImplicitConversion"))
+trait EqualSyntax {
+  import EqualSyntax._
+
+  implicit def ToEqualOps[A](value: A): EqualOps[A] =
+    new EqualOps(value)
+}

--- a/src/test/scala/kevinlee/fp/Gens.scala
+++ b/src/test/scala/kevinlee/fp/Gens.scala
@@ -2,16 +2,27 @@ package kevinlee.fp
 
 import hedgehog._
 
+import kevinlee.fp.testing.TestPredef._
+
 /**
   * @author Kevin Lee
   * @since 2019-06-01
   */
 object Gens {
 
-  def genInts(from: Int, to: Int): Gen[Int] =
+  def genBoolean: Gen[Boolean] =
+    Gen.boolean
+
+  def genDifferentBooleanPair: Gen[(Boolean, Boolean)] =
+    for {
+      x <- Gen.boolean
+      y <- Gen.boolean.map(z => if (x === z) !z else z)
+    } yield (x, y)
+
+  def genInt(from: Int, to: Int): Gen[Int] =
     Gen.int(Range.linear(from, to))
 
-  def genIntFromMinToMax: Gen[Int] = Gens.genInts(Int.MinValue, Int.MaxValue)
+  def genIntFromMinToMax: Gen[Int] = Gens.genInt(Int.MinValue, Int.MaxValue)
 
   def genIntToInt: Gen[Int => Int] =
     /* It has some hard-coded functions for now until Hedgehog has Gen[A => B]
@@ -26,6 +37,159 @@ object Gens {
         , x => x - 100
         , x => x * 100
       )
+
+  def genDifferentIntPair: Gen[(Int, Int)] = for {
+    n1 <- genIntFromMinToMax
+    n2 <- genIntFromMinToMax.map(x => if (x === n1) x + 1 else x)
+  } yield (n1, n2)
+
+  def genLong(from: Long, to: Long): Gen[Long] =
+    Gen.long(Range.linear(from, to))
+
+  def genLongFromMinToMax: Gen[Long] = Gens.genLong(Long.MinValue, Long.MaxValue)
+
+  def genDifferentLongPair: Gen[(Long, Long)] = for {
+    n1 <- genLongFromMinToMax
+    n2 <- genLongFromMinToMax.map(x => if (x === n1) x + 1L else x)
+  } yield (n1, n2)
+
+  def genShort(from: Short, to: Short): Gen[Short] =
+    Gen.short(Range.linear(from, to))
+
+  def genShortFromMinToMax: Gen[Short] = Gens.genShort(Short.MinValue, Short.MaxValue)
+
+  def genDifferentShortPair: Gen[(Short, Short)] = for {
+    n1 <- genShortFromMinToMax
+    n2 <- genShortFromMinToMax.map(x => if (x === n1) (x + 1).toShort else x)
+  } yield (n1, n2)
+
+  def genUnicodeChar: Gen[Char] =
+    Gen.unicode
+
+  def genDifferentUnicodeCharPair: Gen[(Char, Char)] = for {
+    n1 <- genUnicodeChar
+    n2 <- genUnicodeChar.map(x => if (x === n1) (x + 1).toChar else x)
+  } yield (n1, n2)
+
+  def genChar(from: Char, to: Char): Gen[Char] =
+    Gen.char(from, to)
+
+  def genCharFromMinToMax: Gen[Char] = Gens.genChar(Char.MinValue, Char.MaxValue)
+
+  def genDifferentCharPair: Gen[(Char, Char)] = for {
+    n1 <- genCharFromMinToMax
+    n2 <- genCharFromMinToMax.map(x => if (x === n1) (x + 1).toChar else x)
+  } yield (n1, n2)
+
+  def genDouble(from: Double, to: Double): Gen[Double] =
+    Gen.double(Range.linearFracFrom(0, from, to))
+
+  def genDoubleFromMinToMax: Gen[Double] = Gens.genDouble(Float.MinValue.toDouble, Float.MaxValue.toDouble)
+
+  def genAllDouble: Gen[Double] =
+    Gen.frequency1(
+        94 -> genDoubleFromMinToMax
+      , 2 -> Gen.constant(Double.PositiveInfinity)
+      , 2 -> Gen.constant(Double.NegativeInfinity)
+      , 2 -> Gen.constant(Double.NaN)
+      )
+
+  def genAllDoubleNoNaN: Gen[Double] =
+    Gen.frequency1(
+        94 -> genDoubleFromMinToMax
+      , 3 -> Gen.constant(Double.PositiveInfinity)
+      , 3 -> Gen.constant(Double.NegativeInfinity)
+      )
+
+  def genDifferentDoublePair: Gen[(Double, Double)] = for {
+    n1 <- genAllDouble
+    n2 <- genAllDouble.map {
+        case Double.NaN =>
+          Double.NaN
+        case Double.PositiveInfinity =>
+          if (n1 === Double.PositiveInfinity)
+            Double.NegativeInfinity
+          else
+            Double.PositiveInfinity
+        case Double.NegativeInfinity =>
+          if (n1 === Double.NegativeInfinity)
+            Double.PositiveInfinity
+          else
+            Double.NegativeInfinity
+        case x =>
+          if (x === n1) x + 1D else x
+      }
+  } yield (n1, n2)
+
+  def genFloat(from: Float, to: Float): Gen[Float] =
+    Gens.genDouble(from.toDouble, to.toDouble).map(_.toFloat)
+
+  def genFloatFromMinToMax: Gen[Float] = Gens.genFloat(Float.MinValue, Float.MaxValue)
+
+  def genAllFloat: Gen[Float] =
+    Gen.frequency1(
+        94 -> genFloatFromMinToMax
+      , 2 -> Gen.constant(Float.PositiveInfinity)
+      , 2 -> Gen.constant(Float.NegativeInfinity)
+      , 2 -> Gen.constant(Float.NaN)
+    )
+
+  def genAllFloatNoNaN: Gen[Float] =
+    Gen.frequency1(
+        94 -> genFloatFromMinToMax
+      , 3 -> Gen.constant(Float.PositiveInfinity)
+      , 3 -> Gen.constant(Float.NegativeInfinity)
+    )
+
+  def genDifferentFloatPair: Gen[(Float, Float)] = for {
+    n1 <- genAllFloat
+    n2 <- genAllFloat.map {
+      case Float.NaN =>
+        Float.NaN
+      case Float.PositiveInfinity =>
+        if (n1 === Float.PositiveInfinity)
+          Float.NegativeInfinity
+        else
+          Float.PositiveInfinity
+      case Float.NegativeInfinity =>
+        if (n1 === Float.NegativeInfinity)
+          Float.PositiveInfinity
+        else
+          Float.NegativeInfinity
+      case x =>
+        if (x === n1) x + 1F else x
+    }
+  } yield (n1, n2)
+
+  def genUnicodeString: Gen[String] =
+    Gen.string(Gen.unicodeAll, Range.linear(0, 100))
+
+  def genDifferentStringPair: Gen[(String, String)] = for {
+    x <- genUnicodeString
+    y <- genUnicodeString.map(z => if (x === z) "a" + z else z)
+  } yield {
+    (x, y)
+  }
+
+  def genBigInt: Gen[BigInt] =
+    genLongFromMinToMax.map(BigInt(_))
+
+  def genDifferentBigIntPair: Gen[(BigInt, BigInt)] = for {
+    n1 <- genBigInt
+    n2 <- genBigInt.map(x => if (x === n1) x + BigInt(1) else x)
+  } yield {
+    (n1, n2)
+  }
+
+  def genBigDecimal: Gen[BigDecimal] =
+    Gen.choice1(genDoubleFromMinToMax.map(BigDecimal(_)), genBigInt.map(BigDecimal(_)))
+
+  def genDifferentBigDecimalPair: Gen[(BigDecimal, BigDecimal)] = for {
+    n1 <- genBigDecimal
+    n2 <- genBigDecimal.map(x => if (x === n1) x + BigDecimal(1) else x)
+  } yield {
+    (n1, n2)
+  }
 
   def genAToMonadA[M[_], A](genF: Gen[A => A])(implicit m: Monad[M]): Gen[A => M[A]] =
     genF.map(f => x => m.pure(f(x)))

--- a/src/test/scala/kevinlee/fp/syntax/EqualSyntaxSpec.scala
+++ b/src/test/scala/kevinlee/fp/syntax/EqualSyntaxSpec.scala
@@ -1,0 +1,53 @@
+package kevinlee.fp.syntax
+
+import hedgehog._
+import hedgehog.runner._
+
+import kevinlee.fp.Gens
+
+/**
+  * @author Kevin Lee
+  * @since 2019-07-28
+  */
+object EqualSyntaxSpec extends Properties {
+
+  object TestEqualSyntax extends EqualSyntax
+  import TestEqualSyntax._
+  import kevinlee.fp.Equal
+
+  override def tests: List[Prop] = List(
+      property("test Boolean === Boolean", testTripleEquals(Gens.genBoolean))
+    , property("test Int === Int", testTripleEquals(Gens.genIntFromMinToMax))
+    , property("test Short === Short", testTripleEquals(Gens.genShortFromMinToMax))
+    , property("test Long === Long", testTripleEquals(Gens.genLongFromMinToMax))
+    , property("test Char === Char", testTripleEquals(Gens.genUnicodeChar))
+    , property("test Float === Float", testTripleEquals(Gens.genAllFloatNoNaN))
+    , property("test Double === Double", testTripleEquals(Gens.genAllDoubleNoNaN))
+    , property("test String === String", testTripleEquals(Gens.genUnicodeString))
+    , property("test BigInt === BigInt", testTripleEquals(Gens.genBigInt))
+    , property("test BigDecimal === BigDecimal", testTripleEquals(Gens.genBigDecimal))
+    , property("test Boolean !== Boolean", testNotDoubleEquals(Gens.genDifferentBooleanPair))
+    , property("test Int !== Int", testNotDoubleEquals(Gens.genDifferentIntPair))
+    , property("test Short !== Short", testNotDoubleEquals(Gens.genDifferentShortPair))
+    , property("test Long !== Long", testNotDoubleEquals(Gens.genDifferentLongPair))
+    , property("test Char !== Char", testNotDoubleEquals(Gens.genDifferentUnicodeCharPair))
+    , property("test Float !== Float", testNotDoubleEquals(Gens.genDifferentFloatPair))
+    , property("test Double !== Double", testNotDoubleEquals(Gens.genDifferentDoublePair))
+    , property("test String !== String", testNotDoubleEquals(Gens.genDifferentStringPair))
+    , property("test BigInt !== BigInt", testNotDoubleEquals(Gens.genDifferentBigIntPair))
+    , property("test BigDecimal !== BigDecimal", testNotDoubleEquals(Gens.genDifferentBigDecimalPair))
+    )
+
+  def testTripleEquals[A : Equal](gen: Gen[A]): Property = for {
+    x <- gen.log("x")
+  } yield {
+    Result.diff(x, x)(_ === _)
+  }
+
+  def testNotDoubleEquals[A: Equal](gen: Gen[(A, A)]): Property = for {
+    xyPair <- gen.log("(x, y)")
+    (x, y) = xyPair
+  } yield {
+    Result.diff(x, y)(_ !== _)
+  }
+}

--- a/src/test/scala/kevinlee/fp/testing/TestPredef.scala
+++ b/src/test/scala/kevinlee/fp/testing/TestPredef.scala
@@ -1,0 +1,11 @@
+package kevinlee.fp.testing
+
+object TestPredef {
+
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  implicit final class AnyEquals[A](val self: A) extends AnyVal {
+    def ===(other: A): Boolean = self == other
+    def !==(other: A): Boolean = self != other
+  }
+
+}


### PR DESCRIPTION
# Summary
* Close #38 - Add Syntax with `===` and `!==`
  * `Equal` instances for `Boolean`, `Int`, `Short`, `Long`, `Char`, `Float`, `Double`, `String`, `BigInt` and `BigDecimal` have been added.