### PR TITLE
Updated: build.sbt and build.properties

### DIFF
--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -6,11 +6,12 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectScalaVersion: String = "2.13.0"
+  val ProjectScalaVersion: String = "2.13.1"
   val CrossScalaVersions: Seq[String] = Seq("2.10.7", "2.11.12", "2.12.10", ProjectScalaVersion)
 
   val ProjectVersion: String = "1.1.0"
 
-  val commonWarts: Seq[wartremover.Wart] = Warts.allBut(Wart.DefaultArguments, Wart.Overloading, Wart.Any, Wart.Nothing, Wart.NonUnitStatements)
+  val commonWarts: Seq[wartremover.Wart] =
+    Warts.allBut(Wart.DefaultArguments, Wart.Overloading, Wart.Any, Wart.Nothing, Wart.NonUnitStatements)
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.1


### PR DESCRIPTION
# Summary
Updated: build.sbt and build.properties
- Scala `2.13.0` => `2.13.1`
- sbt `1.2.8` => `1.3.1`
