### PR TITLE
Close #80 - Add mappend syntax for SemiGroup and Monoid

### DIFF
--- a/src/main/scala/just/fp/syntax/SemiGroupSyntax.scala
+++ b/src/main/scala/just/fp/syntax/SemiGroupSyntax.scala
@@ -11,6 +11,8 @@ import scala.language.implicitConversions
 object SemiGroupSyntax {
   final class SemiGroupOps[A: SemiGroup] private[syntax](val a1: A) {
     def |+|(a2: A): A = implicitly[SemiGroup[A]].append(a1, a2)
+
+    def mappend(a2: A): A = implicitly[SemiGroup[A]].append(a1, a2)
   }
 }
 

--- a/src/test/scala/just/fp/syntax/SemiGroupSyntaxSpec.scala
+++ b/src/test/scala/just/fp/syntax/SemiGroupSyntaxSpec.scala
@@ -12,8 +12,8 @@ object SemiGroupSyntaxSpec extends Properties {
   import just.fp._
 
   override def tests: List[Test] = List(
-      property("List |+| List", testPlus(Gens.genList(Gens.genIntFromMinToMax, 10)))
-    , property("Vector |+| Vector", testPlus(Gens.genVector(Gens.genIntFromMinToMax, 10)))
+      property("test List |+| List", testPlus(Gens.genList(Gens.genIntFromMinToMax, 10)))
+    , property("test Vector |+| Vector", testPlus(Gens.genVector(Gens.genIntFromMinToMax, 10)))
     , property("test String |+| String", testPlus(Gens.genUnicodeString))
     , property("test Byte |+| Byte", testPlus(Gens.genByteFromMinToMax))
     , property("test Short |+| Short", testPlus(Gens.genShortFromMinToMax))
@@ -22,11 +22,26 @@ object SemiGroupSyntaxSpec extends Properties {
     , property("test Long |+| Long", testPlus(Gens.genLongFromMinToMax))
     , property("test BigInt |+| BigInt", testPlus(Gens.genBigInt))
     , property("test BigDecimal |+| BigDecimal", testPlus(Gens.genBigDecimal))
+    , property("test List.mappend(List)", testMappend(Gens.genList(Gens.genIntFromMinToMax, 10)))
+    , property("test Vector.mappend(Vector)", testMappend(Gens.genVector(Gens.genIntFromMinToMax, 10)))
+    , property("test String.mappend(String)", testMappend(Gens.genUnicodeString))
+    , property("test Byte.mappend(Byte)", testMappend(Gens.genByteFromMinToMax))
+    , property("test Short.mappend(Short)", testMappend(Gens.genShortFromMinToMax))
+    , property("test Char.mappend(Char)", testMappend(Gens.genCharFromMinToMax))
+    , property("test Int.mappend(Int)", testMappend(Gens.genIntFromMinToMax))
+    , property("test Long.mappend(Long)", testMappend(Gens.genLongFromMinToMax))
+    , property("test BigInt.mappend(BigInt)", testMappend(Gens.genBigInt))
+    , property("test BigDecimal.mappend(BigDecimal)", testMappend(Gens.genBigDecimal))
     )
 
   def testPlus[A: SemiGroup](genA: Gen[A]): Property = for {
     a1 <- genA.log("a1")
     a2 <- genA.log("a2")
   } yield (a1 |+| a2) ==== implicitly[SemiGroup[A]].append(a1, a2)
+
+  def testMappend[A: SemiGroup](genA: Gen[A]): Property = for {
+    a1 <- genA.log("a1")
+    a2 <- genA.log("a2")
+  } yield (a1.mappend(a2)) ==== implicitly[SemiGroup[A]].append(a1, a2)
 
 }


### PR DESCRIPTION
# Summary
Close #80 - Add `mappend` syntax for `SemiGroup` and `Monoid`