### PR TITLE
Upgraded: kind-projector and Scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val justFp = (project in file("."))
         Resolver.sonatypeRepo("releases")
       , Deps.hedgehogRepo
       )
-  , addCompilerPlugin("org.typelevel" % "kind-projector" % "0.10.3" cross CrossVersion.binary)
+  , addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full)
   , libraryDependencies := Deps.hedgehogLibs ++
       crossVersionProps(Seq.empty[ModuleID], SemanticVersion.parseUnsafe(scalaVersion.value)) {
         case (Major(2), Minor(10)) =>

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -8,7 +8,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectScalaVersion: String = "2.13.0"
+  val ProjectScalaVersion: String = "2.13.1"
   val CrossScalaVersions: Seq[String] = Seq("2.10.7", "2.11.12", "2.12.10", ProjectScalaVersion)
 
   val ProjectVersion: String = "1.2.0"


### PR DESCRIPTION
# Summary
* Upgraded: 
  * `kind-projector` 0.10.3 => 0.11.0
  * Scala 2.13.0 => 2.13.1 (since kind-projector now supports full Scala version)
