### PR TITLE
Close #102 - Added: apply method to the companion objects of most typeclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Typeclass instances for the following typeclasses are available in `just-fp`.
   1.some.mappend(2.some)
   // Option[Int] = Some(3)
   ```
+  NOTE: There might be an associativity issue with `BigDecimal` if it's created with other `MathContext` than `MathContext.UNLIMITED` and the number is big enough in Scala 2.13. More about the issue please read [this blog](https://blog.kevinlee.io/2019/09/29/be-careful-when-using-bigdecimal-in-scala-2.13).
 
 # Monoid
 // To be updated ...

--- a/src/main/scala/just/fp/Applicative.scala
+++ b/src/main/scala/just/fp/Applicative.scala
@@ -52,7 +52,10 @@ trait Applicative[F[_]] extends Functor[F] {
   def applicativeLaw: ApplicativeLaw = new ApplicativeLaw {}
 }
 
-object Applicative extends ApplicativeInstances
+object Applicative extends ApplicativeInstances {
+
+  @inline final def apply[F[_] : Applicative]: Applicative[F] = implicitly[Applicative[F]]
+}
 
 private[fp] trait ApplicativeInstances
   extends OptionApplicativeInstance

--- a/src/main/scala/just/fp/EitherT.scala
+++ b/src/main/scala/just/fp/EitherT.scala
@@ -58,10 +58,10 @@ final case class EitherT[F[_], A, B](run: F[Either[A, B]]) {
 
 object EitherT extends EitherTMonadInstance {
   def pure[F[_]: Applicative, A, B](b: B): EitherT[F, A, B] =
-    EitherT(implicitly[Applicative[F]].pure(Right(b)))
+    EitherT(Applicative[F].pure(Right(b)))
 
   def pureLeft[F[_]: Applicative, A, B](a: A): EitherT[F, A, B] =
-    EitherT(implicitly[Applicative[F]].pure(Left(a)))
+    EitherT(Applicative[F].pure(Left(a)))
 }
 
 private trait EitherTFunctor[F[_], A] extends Functor[EitherT[F, A, *]] {

--- a/src/main/scala/just/fp/Equal.scala
+++ b/src/main/scala/just/fp/Equal.scala
@@ -62,7 +62,10 @@ object Equal
     with OptionEqualInstance
     with EitherEqualInstance
     with ListEqualInstance
-    with VectorEqualInstance
+    with VectorEqualInstance {
+
+  @inline final def apply[F : Equal]: Equal[F] = implicitly[Equal[F]]
+}
 
 trait NatualEqual {
   def equalA[A]: Equal[A] = new Equal[A] {

--- a/src/main/scala/just/fp/Functor.scala
+++ b/src/main/scala/just/fp/Functor.scala
@@ -28,7 +28,10 @@ trait Functor[F[_]] {
   def functorLaw: FunctorLaw = new FunctorLaw {}
 }
 
-object Functor extends FunctorInstances
+object Functor extends FunctorInstances {
+
+  @inline final def apply[F[_] : Functor]: Functor[F] = implicitly[Functor[F]]
+}
 
 private[fp] trait FunctorInstances
   extends OptionFunctorInstance

--- a/src/main/scala/just/fp/Monad.scala
+++ b/src/main/scala/just/fp/Monad.scala
@@ -41,7 +41,10 @@ trait Monad[M[_]] extends Applicative[M] {
   def monadLaw: MonadLaw = new MonadLaw {}
 }
 
-object Monad extends MonadInstances
+object Monad extends MonadInstances {
+
+  @inline final def apply[M[_] : Monad]: Monad[M] = implicitly[Monad[M]]
+}
 
 private[fp] trait MonadInstances
   extends IdInstance

--- a/src/main/scala/just/fp/Monoid.scala
+++ b/src/main/scala/just/fp/Monoid.scala
@@ -35,6 +35,8 @@ trait Monoid[A] extends SemiGroup[A] {
 
 object Monoid extends OptionMonoidInstance {
 
+  @inline final def apply[A : Monoid]: Monoid[A] = implicitly[Monoid[A]]
+
   implicit def listMonoid[A]: Monoid[List[A]] = new Monoid[List[A]] with ListSemiGroup[A] {
     override def zero: List[A] = Nil
   }

--- a/src/main/scala/just/fp/SemiGroup.scala
+++ b/src/main/scala/just/fp/SemiGroup.scala
@@ -10,6 +10,8 @@ trait SemiGroup[A] {
 
 object SemiGroup extends OptionSemiGroupInstance {
 
+  @inline final def apply[A : SemiGroup]: SemiGroup[A] = implicitly[SemiGroup[A]]
+
   trait ListSemiGroup[A] extends SemiGroup[List[A]] {
     override def append(a1: List[A], a2: => List[A]): List[A] = a1 ++ a2
   }
@@ -67,7 +69,7 @@ private[fp] trait OptionSemigroup[A] extends SemiGroup[Option[A]] {
 
   override def append(a1: Option[A], a2: => Option[A]): Option[A] = (a1, a2) match {
     case (Some(x), Some(y)) =>
-      Some(implicitly[SemiGroup[A]].append(x, y))
+      Some(SemiGroup[A].append(x, y))
     case (Some(x), None) =>
       Some(x)
     case (None, Some(y)) =>

--- a/src/main/scala/just/fp/syntax/SemiGroupSyntax.scala
+++ b/src/main/scala/just/fp/syntax/SemiGroupSyntax.scala
@@ -10,9 +10,9 @@ import scala.language.implicitConversions
   */
 object SemiGroupSyntax {
   final class SemiGroupOps[A: SemiGroup] private[syntax](val a1: A) {
-    def |+|(a2: A): A = implicitly[SemiGroup[A]].append(a1, a2)
+    def |+|(a2: A): A = SemiGroup[A].append(a1, a2)
 
-    def mappend(a2: A): A = implicitly[SemiGroup[A]].append(a1, a2)
+    def mappend(a2: A): A = SemiGroup[A].append(a1, a2)
   }
 }
 


### PR DESCRIPTION
# Summary
Close #102 - Added: apply method to the companion objects of most typeclasses to get typeclass instances conveniently
(e.g. `Monoid[List[Int]]` instead of `implicitly[Monoid[List[Int]]]`)