### PR TITLE
just-fp v1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In `build.sbt`,
 ```sbt
 resolvers += "Just Repo" at "https://dl.bintray.com/kevinlee/maven"
 
-libraryDependencies += "kevinlee" %% "just-fp" % "1.3.1"
+libraryDependencies += "io.kevinlee" %% "just-fp" % "1.3.2"
 ```
 then import
 

--- a/changelogs/1.3.2.md
+++ b/changelogs/1.3.2.md
@@ -1,0 +1,7 @@
+## [1.3.2](https://github.com/Kevin-Lee/just-fp/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone11%22) - 2019-10-18
+
+### Done
+* Set up GitHub Actions (#113)
+* Change group id for publishing to `io.kevinlee` (#116)
+
+**NOTE: No important changes to public. Only the group ID is not `io.kevinlee` which was `kevinlee` before.**

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -11,7 +11,7 @@ object ProjectInfo {
   val ProjectScalaVersion: String = "2.13.1"
   val CrossScalaVersions: Seq[String] = Seq("2.10.7", "2.11.12", "2.12.10", ProjectScalaVersion)
 
-  val ProjectVersion: String = "1.3.1"
+  val ProjectVersion: String = "1.3.2"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# just-fp v1.3.2

## [1.3.2](https://github.com/Kevin-Lee/just-fp/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3A%22milestone11%22) - 2019-10-18

### Done
* Set up GitHub Actions (#113)
* Change group id for publishing to `io.kevinlee` (#116)

**NOTE: No important changes to public. Only the group ID is not `io.kevinlee` which was `kevinlee` before.**
