### PR TITLE
Task #142 - Add document site using sbt-microsites

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -1,7 +1,7 @@
 name: Publish GitHub Pages
 
 on:
-  pull_request:
+  push:
     branches:
       - publish-docs
 


### PR DESCRIPTION
# Summary
Task #142 - Add document site using sbt-microsites
* publish to GitHub Pages when pushing to publish-docs