### PR TITLE
just-fp v1.4.0

### DIFF
--- a/changelogs/1.4.0.md
+++ b/changelogs/1.4.0.md
@@ -1,0 +1,12 @@
+## [1.4.0](https://github.com/Kevin-Lee/just-fp/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2021-04-18
+
+### Done
+* Add `OptionT` (#132)
+* ~~Add the document site using `sbt-microsites`~~ (#142)
+* Add core sub-project (#143)
+* Replace `sbt-microsites` with `Docusaurus` (#165)
+* Build for Dotty (#170)
+* ~~Support Scala `3.0.0-M2`~~ (#180)
+* Support ~~Scala `3.0.0-M3`~~, Scala `3.0.0-RC1` and Scala `3.0.0-RC2` (#186)
+* Use `Scalafix` (#190)
+* Drop Scala `3.0.0-M*` support (#192)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -8,7 +8,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectVersion: String = "1.3.5"
+  val ProjectVersion: String = "1.4.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# just-fp v1.4.0
## [1.4.0](https://github.com/Kevin-Lee/just-fp/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2021-04-18

### Done
* Add `OptionT` (#132)
* ~~Add the document site using `sbt-microsites`~~ (#142)
* Add core sub-project (#143)
* Replace `sbt-microsites` with `Docusaurus` (#165)
* Build for Dotty (#170)
* ~~Support Scala `3.0.0-M2`~~ (#180)
* Support ~~Scala `3.0.0-M3`~~, Scala `3.0.0-RC1` and Scala `3.0.0-RC2` (#186)
* Use `Scalafix` (#190)
* Drop Scala `3.0.0-M*` support (#192)
