### PR TITLE
just-fp v1.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ libraryDependencies := (
 libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value))
 
 lazy val core = (project in file("core"))
-  .enablePlugins(DevOopsGitHubReleasePlugin)
 //  .disablePlugins((if (isDotty.value) List(WartRemover) else Seq.empty[AutoPlugin]):_*)
   .settings(
     name := prefixedProjectName("core"),
@@ -222,10 +221,14 @@ lazy val docs = (project in file("generated-docs"))
   .dependsOn(core)
 
 lazy val justFp = (project in file("."))
+  .enablePlugins(DevOopsGitHubReleasePlugin)
   .settings(
     name := prefixedProjectName(""),
     description := "Just FP Lib",
-    semanticdbEnabled := false
+    semanticdbEnabled := false,
+    devOopsPackagedArtifacts := List(
+      s"*/target/scala-*/${name.value}*.jar",
+    ),
   )
   .settings(noPublish)
   .settings(noDoc)


### PR DESCRIPTION
# just-fp v1.4.0
## [1.4.0](https://github.com/Kevin-Lee/just-fp/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2021-04-18

### Done
* Add `OptionT` (#132)
* ~~Add the document site using `sbt-microsites`~~ (#142)
* Add core sub-project (#143)
* Replace `sbt-microsites` with `Docusaurus` (#165)
* Build for Dotty (#170)
* ~~Support Scala `3.0.0-M2`~~ (#180)
* Support ~~Scala `3.0.0-M3`~~, Scala `3.0.0-RC1` and Scala `3.0.0-RC2` (#186)
* Use `Scalafix` (#190)
* Drop Scala `3.0.0-M*` support (#192)
