### PR TITLE
just-fp v1.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,9 @@ jobs:
           export SOURCE_DATE_EPOCH=$(date +%s)
           echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
           echo 'sbt -J-Xmx2048m -v clean +test +packagedArtifacts ci-release devOopsGitHubReleaseUploadArtifacts'
-          sbt -J-Xmx2048m \
+          sbt \
+            -J-XX:MaxMetaspaceSize=1024m \
+            -J-Xmx2048m \
             -v \
             clean \
             +test \


### PR DESCRIPTION
# just-fp v1.4.0
## [1.4.0](https://github.com/Kevin-Lee/just-fp/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13) - 2021-04-18

### Done
* Add `OptionT` (#132)
* ~~Add the document site using `sbt-microsites`~~ (#142)
* Add core sub-project (#143)
* Replace `sbt-microsites` with `Docusaurus` (#165)
* Build for Dotty (#170)
* ~~Support Scala `3.0.0-M2`~~ (#180)
* Support ~~Scala `3.0.0-M3`~~, Scala `3.0.0-RC1` and Scala `3.0.0-RC2` (#186)
* Use `Scalafix` (#190)
* Drop Scala `3.0.0-M*` support (#192)
