### PR TITLE
just-fp v1.6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-
 
-      - name: "[Push] Build All for ${{ matrix.scala.name }} ${{ matrix.scala.version }} - ${{ github.run_number }}"
+      - name: "[Push] Build All for ${{ matrix.scala.name }}: ${{ matrix.scala.version }} - ${{ github.run_number }}"
         if: github.event_name == 'push'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/changelogs/1.6.0.md
+++ b/changelogs/1.6.0.md
@@ -1,0 +1,5 @@
+## [1.6.0](https://github.com/Kevin-Lee/just-fp/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone15) - 2021-05-15
+
+### Done
+* Drop Scala `2.10` support (#210)
+* Support Scala `3.0.0` (#212)


### PR DESCRIPTION
# just-fp v1.6.0
## [1.6.0](https://github.com/Kevin-Lee/just-fp/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone15) - 2021-05-15

### Done
* Drop Scala `2.10` support (#210)
* Support Scala `3.0.0` (#212)
