### PR TITLE
Upgrade: sbt plugins - sbt-mdoc, sbt-docusaur and sbt-devoops

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,11 +4,11 @@ addSbtPlugin("com.geirsson"    % "sbt-ci-release"  % "1.5.7")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
 addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "1.6.1")
 addSbtPlugin("org.scoverage"   % "sbt-coveralls"   % "1.2.7")
-addSbtPlugin("org.scalameta"   % "sbt-mdoc"        % "2.2.21")
-addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.5.0")
+addSbtPlugin("org.scalameta"   % "sbt-mdoc"        % "2.3.2")
+addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.11.0")
 addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"    % "0.9.28")
 
-val sbtDevOopsVersion = "2.6.0"
+val sbtDevOopsVersion = "2.22.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
# Summary
Upgrade: sbt plugins - sbt-mdoc, sbt-docusaur and sbt-devoops
* sbt-mdoc: 2.2.21 => 2.3.2
* sbt-docusaur: 0.5.0 => 0.11.0
* sbt-devoops: 2.6.0 => 2.22.0
