### PR TITLE
Bump sbt and sbt plugins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         scala:
           - { name: 'Scala 2', version: "2.11.12", binary-version: "2.11", java-version: "adopt@1.8" , report: "" }
           - { name: 'Scala 2', version: "2.12.12", binary-version: "2.12", java-version: "adopt@1.11", report: "" }
-          - { name: 'Scala 2', version: "2.13.3",  binary-version: "2.13", java-version: "adopt@1.11", report: "report" }
+          - { name: 'Scala 2', version: "2.13.10", binary-version: "2.13", java-version: "adopt@1.11", report: "report" }
           - { name: 'Scala 3', version: "3.0.0",   binary-version: "3",    java-version: "adopt@1.11", report: "" }
 
     steps:

--- a/.github/workflows/m-doc-site-publish.yml
+++ b/.github/workflows/m-doc-site-publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.5", binary-version: "2.13", java-version: "11" }
+          - { version: "2.13.10", binary-version: "2.13", java-version: "11" }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/sbt-build-all.sh
+++ b/.github/workflows/sbt-build-all.sh
@@ -5,7 +5,7 @@ set -x
 if [ -z "$1" ]
   then
     echo "Missing parameters. Please enter the [Scala version]."
-    echo "sbt-build.sh 2.13.3"
+    echo "sbt-build.sh 2.13.10"
     exit 1
 else
   : ${CURRENT_BRANCH_NAME:?"CURRENT_BRANCH_NAME is missing."}
@@ -18,14 +18,14 @@ else
   echo ""
 
   test_task="test"
-  if [[ $scala_version == 2* ]] ;
+  if [[ $scala_version == 2.12* || $scala_version == 2.13* ]] ;
   then
     test_task="${test_task} scalafix"
   fi
 
   if [ "$2" == "report" ]
   then
-    test_task="coverage ${test_task} coverageReport coverageAggregate coveralls"
+    test_task="coverage ${test_task} coverageReport coverageAggregate"
   fi
 
   echo "sbt -J-Xmx2048m ++${scala_version}! -v clean ${test_task}"

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val core = (project in file("core"))
         case "2.12" =>
           List("com.lihaoyi" % "ammonite" % "2.3.8-58-aa8b2ab1" % Test cross CrossVersion.full)
         case "2.13" =>
-          List("com.lihaoyi" % "ammonite" % "2.3.8-65-0f0d597f" % Test cross CrossVersion.full)
+          List("com.lihaoyi" % "ammonite" % "2.5.9" % Test cross CrossVersion.full)
         case _      =>
           Seq.empty[ModuleID]
       }),
@@ -102,10 +102,16 @@ lazy val core = (project in file("core"))
       (scalaBinaryVersion.value match {
         case "2.10"                   =>
           task(Seq.empty[File])
-        case "2.11" | "2.12" | "2.13" =>
+        case "2.11" | "2.12" =>
           task {
             val file = (Test / sourceManaged).value / "amm.scala"
             IO.write(file, """object amm extends App { ammonite.Main.main(args) }""")
+            List(file)
+          }
+        case "2.13" =>
+          task {
+            val file = (Test / sourceManaged).value / "amm.scala"
+            IO.write(file, """object amm extends App { ammonite.AmmoniteMain.main(args) }""")
             List(file)
           }
         case _                        =>
@@ -193,7 +199,7 @@ lazy val props =
   new {
 
     val DottyVersions       = List("3.0.0")
-    val ProjectScalaVersion = "2.13.3"
+    val ProjectScalaVersion = "2.13.10"
 
     val removeDottyIncompatible: ModuleID => Boolean =
       m =>
@@ -206,7 +212,7 @@ lazy val props =
       (List(
         "2.11.12",
         "2.12.12",
-        "2.13.3"
+        "2.13.10"
       ) ++ DottyVersions).distinct
 
     val GitHubUsername = "Kevin-Lee"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.9.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,15 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.geirsson"    % "sbt-ci-release"  % "1.5.7")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
-addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "1.6.1")
-addSbtPlugin("org.scoverage"   % "sbt-coveralls"   % "1.2.7")
+addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.12")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.20")
+addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"    % "0.11.0")
+addSbtPlugin("org.scalameta"   % "sbt-scalafmt"    % "2.5.0")
+addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "2.0.8")
 addSbtPlugin("org.scalameta"   % "sbt-mdoc"        % "2.3.2")
-addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.12.0")
-addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"    % "0.9.28")
+addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.13.0")
 
-val sbtDevOopsVersion = "2.23.0"
+val sbtDevOopsVersion = "2.24.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
-addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"    % sbtDevOopsVersion)
+addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % sbtDevOopsVersion)


### PR DESCRIPTION
# Summary
Bump sbt and sbt plugins
- sbt to 1.9.4
- sbt-ci-release to 1.5.12
- sbt-scalafix to 0.11.0
- sbt-scalafmt to 2.5.0
- sbt-scoverage to 2.0.8
- sbt-docusaur to 0.13.0
- sbt-devoops to 2.24.0
