### PR TITLE
Update GitHub Actions to use `actions/cache@v4` for SBT and npm caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: ${{ matrix.scala.java-version }}
 
       - name: Cache SBT
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/m-doc-site-publish.yml
+++ b/.github/workflows/m-doc-site-publish.yml
@@ -26,7 +26,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Cache SBT
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.ivy2/cache
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-
 
       - name: Cache npm
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: ${{ env.GH_JAVA_VERSION }}
 
       - name: Cache SBT
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.ivy2/cache
@@ -63,7 +63,7 @@ jobs:
       - uses: olafurpg/setup-gpg@v3
 
       - name: Cache SBT
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.ivy2/cache
@@ -112,7 +112,7 @@ jobs:
       - uses: olafurpg/setup-gpg@v3
 
       - name: Cache SBT
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.ivy2/cache


### PR DESCRIPTION
# Summary
Update GitHub Actions to use `actions/cache@v4` for SBT and npm caching