### PR TITLE
Update Scala versions, sbt and dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         scala:
           - { name: 'Scala 2', version: "2.11.12", binary-version: "2.11", java-version: "11", java-distribution: "temurin", report: "" }
-          - { name: 'Scala 2', version: "2.12.12", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: 'Scala 2', version: "2.12.18", binary-version: "2.12", java-version: "11", java-distribution: "temurin", report: "" }
           - { name: 'Scala 2', version: "2.13.11", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
-          - { name: 'Scala 3', version: "3.0.0",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: 'Scala 3', version: "3.3.4",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/m-doc-site-publish.yml
+++ b/.github/workflows/m-doc-site-publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.10", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
+          - { version: "2.13.11", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
           - { version: "18.13.0" }
 

--- a/build.sbt
+++ b/build.sbt
@@ -82,9 +82,9 @@ lazy val core = module("core")
         case "2.11" =>
           List("com.lihaoyi" % "ammonite" % "1.6.7-2-c28002d" % Test cross CrossVersion.full)
         case "2.12" =>
-          List("com.lihaoyi" % "ammonite" % "2.3.8-58-aa8b2ab1" % Test cross CrossVersion.full)
+          List("com.lihaoyi" % "ammonite" % "3.0.7" % Test cross CrossVersion.full)
         case "2.13" =>
-          List("com.lihaoyi" % "ammonite" % "2.5.9" % Test cross CrossVersion.full)
+          List("com.lihaoyi" % "ammonite" % "3.0.7" % Test cross CrossVersion.full)
         case _ =>
           Seq.empty[ModuleID]
       }),
@@ -95,19 +95,19 @@ lazy val core = module("core")
           .value
           .filterNot(props.removeDottyIncompatible)
       } else
-        (libraryDependencies).value
+        libraryDependencies.value
     ),
     Test / sourceGenerators +=
       (scalaBinaryVersion.value match {
         case "2.10" =>
           task(Seq.empty[File])
-        case "2.11" | "2.12" =>
+        case "2.11" =>
           task {
             val file = (Test / sourceManaged).value / "amm.scala"
             IO.write(file, """object amm extends App { ammonite.Main.main(args) }""")
             List(file)
           }
-        case "2.13" =>
+        case "2.12" | "2.13" =>
           task {
             val file = (Test / sourceManaged).value / "amm.scala"
             IO.write(file, """object amm extends App { ammonite.AmmoniteMain.main(args) }""")
@@ -198,7 +198,7 @@ lazy val justFp = (project in file("."))
 lazy val props =
   new {
 
-    val DottyVersions       = List("3.0.0")
+    val DottyVersions       = List("3.3.4")
     val ProjectScalaVersion = "2.13.11"
 
     val SonatypeCredentialHost = "s01.oss.sonatype.org"
@@ -218,8 +218,8 @@ lazy val props =
     val CrossScalaVersions: Seq[String] =
       (List(
         "2.11.12",
-        "2.12.12",
-        "2.13.10"
+        "2.12.18",
+        "2.13.11"
       ) ++ DottyVersions).distinct
 
     val GitHubUsername = "Kevin-Lee"

--- a/modules/just-fp-core/src/test/scala-2/just/fp/syntax/EqualSyntaxSpec.scala
+++ b/modules/just-fp-core/src/test/scala-2/just/fp/syntax/EqualSyntaxSpec.scala
@@ -43,8 +43,7 @@ object EqualSyntaxSpec extends Properties {
   }
 
   def testNotDoubleEquals[A: Equal](gen: Gen[(A, A)]): Property = for {
-    xyPair <- gen.log("(x, y)")
-    (x, y) = xyPair
+    (x, y) <- gen.log("(x, y)")
   } yield {
     Result.diff(x, y)(_ !== _)
   }

--- a/modules/just-fp-core/src/test/scala-3/just/fp/syntax/EqualSyntaxSpec.scala
+++ b/modules/just-fp-core/src/test/scala-3/just/fp/syntax/EqualSyntaxSpec.scala
@@ -1,0 +1,50 @@
+package just.fp.syntax
+
+import hedgehog._
+import hedgehog.runner._
+
+import just.fp.Gens
+
+/** @author Kevin Lee
+  * @since 2019-07-28
+  */
+object EqualSyntaxSpec extends Properties {
+
+  import just.fp.Equal
+
+  override def tests: List[Prop] = List(
+    property("test Boolean === Boolean", testTripleEquals(Gens.genBoolean)),
+    property("test Int === Int", testTripleEquals(Gens.genIntFromMinToMax)),
+    property("test Short === Short", testTripleEquals(Gens.genShortFromMinToMax)),
+    property("test Long === Long", testTripleEquals(Gens.genLongFromMinToMax)),
+    property("test Char === Char", testTripleEquals(Gens.genUnicodeChar)),
+    property("test Float === Float", testTripleEquals(Gens.genAllFloatNoNaN)),
+    property("test Double === Double", testTripleEquals(Gens.genAllDoubleNoNaN)),
+    property("test String === String", testTripleEquals(Gens.genUnicodeString)),
+    property("test BigInt === BigInt", testTripleEquals(Gens.genBigIntFromMinToMaxLong)),
+    property("test BigDecimal === BigDecimal", testTripleEquals(Gens.genBigDecimalFromMinToMaxFloatLong)),
+    property("test Boolean !== Boolean", testNotDoubleEquals(Gens.genDifferentBooleanPair)),
+    property("test Int !== Int", testNotDoubleEquals(Gens.genDifferentIntPair)),
+    property("test Short !== Short", testNotDoubleEquals(Gens.genDifferentShortPair)),
+    property("test Long !== Long", testNotDoubleEquals(Gens.genDifferentLongPair)),
+    property("test Char !== Char", testNotDoubleEquals(Gens.genDifferentUnicodeCharPair)),
+    property("test Float !== Float", testNotDoubleEquals(Gens.genDifferentFloatPair)),
+    property("test Double !== Double", testNotDoubleEquals(Gens.genDifferentDoublePair)),
+    property("test String !== String", testNotDoubleEquals(Gens.genDifferentStringPair)),
+    property("test BigInt !== BigInt", testNotDoubleEquals(Gens.genDifferentBigIntPair)),
+    property("test BigDecimal !== BigDecimal", testNotDoubleEquals(Gens.genDifferentBigDecimalPair))
+  )
+
+  def testTripleEquals[A: Equal](gen: Gen[A]): Property = for {
+    x <- gen.log("x")
+  } yield {
+    Result.diff(x, x)(_ === _)
+  }
+
+  def testNotDoubleEquals[A: Equal](gen: Gen[(A, A)]): Property = for {
+    xyPair <- gen.log("(x, y)")
+    (x, y) = xyPair
+  } yield {
+    Result.diff(x, y)(_ !== _)
+  }
+}

--- a/modules/just-fp-core/src/test/scala/just/fp/testing/TypeUtil.scala
+++ b/modules/just-fp-core/src/test/scala/just/fp/testing/TypeUtil.scala
@@ -8,6 +8,9 @@ import scala.reflect.ClassTag
   */
 object TypeUtil {
 
-  def getRuntimeClass[A: ClassTag](a: A): Class[_] = implicitly[ClassTag[A]].runtimeClass
+  def getRuntimeClass[A: ClassTag](a: A): Class[_] = {
+    val _ = a
+    implicitly[ClassTag[A]].runtimeClass
+  }
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.12.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.scoverage"   % "sbt-scoverage"   % "2.0.8")
 addSbtPlugin("org.scalameta"   % "sbt-mdoc"        % "2.3.2")
 addSbtPlugin("io.kevinlee"     % "sbt-docusaur"    % "0.13.0")
 
-val sbtDevOopsVersion = "2.24.0"
+val sbtDevOopsVersion = "3.3.2"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
# Update Scala versions, sbt and dependencies

- Bump sbt to 1.12.0
- Update Scala 3 to `3.3.4`
- Update Scala 2.13 to `2.13.11`
- Update Scala 2.12 to `2.12.18`
- Update Ammonite to `3.0.7`
- Update `sbt-devoops` to `3.3.2`
- Split `EqualSyntaxSpec` for Scala 2 and 3
- Fix unused parameter warning in `TypeUtil`