### PR TITLE
Remove unused Maven Central publishing settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,6 @@ ThisBuild / scmInfo :=
   ).some
 ThisBuild / licenses := props.licenses
 
-ThisBuild / resolvers += props.SonatypeSnapshots
-
 libraryDependencies := (
   if (isScala3(scalaVersion.value))
     libraryDependencies
@@ -190,7 +188,6 @@ lazy val justFp = (project in file("."))
       s"*/target/scala-*/${name.value}*.jar",
     ),
   )
-  .settings(mavenCentralPublishSettings)
   .settings(noPublish)
   .settings(noDoc)
   .aggregate(core)
@@ -200,11 +197,6 @@ lazy val props =
 
     val DottyVersions       = List("3.3.4")
     val ProjectScalaVersion = "2.13.11"
-
-    val SonatypeCredentialHost = "s01.oss.sonatype.org"
-    val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
-
-    val SonatypeSnapshots = "sonatype-snapshots" at s"https://$SonatypeCredentialHost/content/repositories/snapshots"
 
     val licenses = List(License.MIT)
 
@@ -238,12 +230,6 @@ lazy val libs =
     )
   }
 
-lazy val mavenCentralPublishSettings: SettingsDefinition = List(
-  /* Publish to Maven Central { */
-  sonatypeCredentialHost := props.SonatypeCredentialHost,
-  sonatypeRepository := props.SonatypeRepository,
-  /* } Publish to Maven Central */
-)
 
 def prefixedProjectName(name: String) =
   s"${props.ProjectName}${if (name.isEmpty) "" else s"-$name"}"
@@ -256,5 +242,4 @@ def module(projectName: String) = {
     .settings(
       name := prefixedName,
     )
-    .settings(mavenCentralPublishSettings)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.5.12")
+addSbtPlugin("com.github.sbt"  % "sbt-ci-release"  % "1.11.2")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.21")
 addSbtPlugin("ch.epfl.scala"   % "sbt-scalafix"    % "0.11.0")
 addSbtPlugin("org.scalameta"   % "sbt-scalafmt"    % "2.5.0")


### PR DESCRIPTION
## Remove unused Maven Central publishing settings
- Bump `sbt-ci-release` to `1.11.2`
- Remove `mavenCentralPublishSettings` and usages
- Remove Sonatype-related properties from `props`
- Remove Sonatype snapshots resolver

These are unused and shouldn't be there as Maven Central deprecated them, and new settings will be handled by the new sbt (`1.11.0+`) and sbt-ci-release (`1.11.1+`)
